### PR TITLE
Update asset urls to reflect new package name

### DIFF
--- a/packages/meteor-gazelle-theme/stylesheets/_font-awesome-custom.scss
+++ b/packages/meteor-gazelle-theme/stylesheets/_font-awesome-custom.scss
@@ -1,4 +1,4 @@
-$fa-font-path: '/packages/gazelle-theme/.npm/package/node_modules/font-awesome/fonts/';
+$fa-font-path: '/packages/meteor-gazelle-theme/.npm/package/node_modules/font-awesome/fonts/';
 
 @import 'font-awesome/scss/variables';
 @import 'font-awesome/scss/mixins';

--- a/packages/meteor-gazelle-theme/stylesheets/_variables.scss
+++ b/packages/meteor-gazelle-theme/stylesheets/_variables.scss
@@ -29,4 +29,4 @@ $layout-gutter: 1.875em;
 
 $animation-slide-offset: -15%;
 
-$path-images: '/packages/gazelle-theme/images';
+$path-images: '/packages/meteor-gazelle-theme/images';


### PR DESCRIPTION
Closes #129.

Update urls in the stylesheets to reflect the new `meteor-gazelle-theme` package directory.
