### PR TITLE
Fix asset path in stylesheets

### DIFF
--- a/packages/meteor-gazelle-theme/stylesheets/_font-awesome-custom.scss
+++ b/packages/meteor-gazelle-theme/stylesheets/_font-awesome-custom.scss
@@ -1,4 +1,4 @@
-$fa-font-path: '/packages/meteor-gazelle-theme/.npm/package/node_modules/font-awesome/fonts/';
+$fa-font-path: '#{$path-package}/.npm/package/node_modules/font-awesome/fonts/';
 
 @import 'font-awesome/scss/variables';
 @import 'font-awesome/scss/mixins';

--- a/packages/meteor-gazelle-theme/stylesheets/_fonts.scss
+++ b/packages/meteor-gazelle-theme/stylesheets/_fonts.scss
@@ -11,7 +11,7 @@ $fonts: (
 @each $name, $path in $fonts {
   @include font-face(
     $name,
-    '/packages/gazelle-theme/fonts/#{$path}',
+    '#{$path-package}/fonts/#{$path}',
     $file-formats: eot woff ttf svg
   );
 }

--- a/packages/meteor-gazelle-theme/stylesheets/_variables.scss
+++ b/packages/meteor-gazelle-theme/stylesheets/_variables.scss
@@ -29,4 +29,5 @@ $layout-gutter: 1.875em;
 
 $animation-slide-offset: -15%;
 
-$path-images: '/packages/meteor-gazelle-theme/images';
+$path-package: '/packages/meteor-gazelle-theme';
+$path-images: '#{$path-package}/images';

--- a/packages/meteor-gazelle-theme/stylesheets/core.scss
+++ b/packages/meteor-gazelle-theme/stylesheets/core.scss
@@ -1,3 +1,6 @@
 @import 'bourbon';
+@import 'neat';
 @import 'normalize';
+@import 'variables';
+@import 'mixins';
 @import 'fonts';

--- a/packages/meteor-gazelle-theme/stylesheets/default.scss
+++ b/packages/meteor-gazelle-theme/stylesheets/default.scss
@@ -1,7 +1,3 @@
 @import 'core';
-@import 'bourbon';
-@import 'neat';
 @import 'font-awesome-custom';
-@import 'variables';
-@import 'mixins';
 @import 'layout';

--- a/packages/meteor-gazelle-theme/stylesheets/public.scss
+++ b/packages/meteor-gazelle-theme/stylesheets/public.scss
@@ -1,5 +1,3 @@
 @import 'core';
-@import 'variables';
-@import 'mixins';
 @import 'useraccounts';
 @import 'public';


### PR DESCRIPTION
Closes #129. For real.

Move package path to its own variable. Apply to images, font, and npm packages.
