### PR TITLE
Replace colon with underscore in asset URL

### DIFF
--- a/packages/meteor-gazelle-theme/stylesheets/_variables.scss
+++ b/packages/meteor-gazelle-theme/stylesheets/_variables.scss
@@ -29,5 +29,5 @@ $layout-gutter: 1.875em;
 
 $animation-slide-offset: -15%;
 
-$path-package: '/packages/meteor-gazelle-theme';
+$path-package: '/packages/meteor-gazelle_theme';
 $path-images: '#{$path-package}/images';


### PR DESCRIPTION
Resolves #156 

Replaces the colon with an underscore in the asset URLs... as is the meteor way.
